### PR TITLE
fix: annotation has to be on new line or it breaks the EOT

### DIFF
--- a/docs/terraform/style-guide.md
+++ b/docs/terraform/style-guide.md
@@ -22,7 +22,8 @@ variable "project_id" { # (1)!
     error_message = <<-EOT
       Variable `project_id` must start with a lowercase letter, be 6–30 chars, and contain only lowercase
       letters, digits, or hyphens (no trailing hyphen).
-    EOT # (6)!
+    EOT
+    # (6)!
   }
 }
 ```


### PR DESCRIPTION
## Summary

## 🐛 Bug Fixes
- annotation has to be on new line or it breaks the EOT [`e9979f5`](https://github.com/RemoteRabbit/boilplate/commit/e9979f5)

## 📁 File Changes

### Documentation (+2/-1 lines)
- `docs/terraform/style-guide.md` (+2/-1) 📝

---

**Changes:** 1 files, +2 insertions, -1 deletions
**Commits:** 1
**Branch:** `fix/code-annotation-break`
**Base:** `origin/main`