### PR TITLE
fix(style-guide): Adjust rule four for var validation to exclude bool…

### DIFF
--- a/docs/terraform/style-guide.md
+++ b/docs/terraform/style-guide.md
@@ -34,8 +34,8 @@ lowercase with only letters and underscores.
 for multiline detailed descriptions.
 3. Be explicit when it comes to variable types. If it is a map or object be diligent with marking that in the type along
 with its internal types.
-4. All variables should have at least one level of validation. Even if it is a simple variable that is always set in a
-vars file. Typos and mistakes happen. Validation catches that ahead of time.
+4. All variables should have at least one level of validation, excluding variables of type `bool`. Even if it is a
+simple variable that is always set in a vars file. Typos and mistakes happen. Validation catches that ahead of time.
 5. Create a condition that is as strict to the type and desired state of the variable without it becoming its own
 project to manage. Strict enough to catch real mistakes, loose enough not to require updating every time the
 upstream naming rules shift.


### PR DESCRIPTION
## Summary

Adjust rule four for variable validation requirement. Since if the variable is of type `bool` there really isn't a good use case for a validation block.

## 🐛 Bug Fixes
- Adjust rule four for var validation to exclude bool vars [`2100afe`](https://github.com/RemoteRabbit/boilplate/commit/2100afe)

## 📁 File Changes

### Documentation (+2/-2 lines)
- `docs/terraform/style-guide.md` (+2/-2) 📝

---

**Changes:** 1 files, +2 insertions, -2 deletions
**Commits:** 1
**Branch:** `fix/adjust-var-val-rule-4`
**Base:** `origin/main`